### PR TITLE
Prepare 1.0.1 Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "patch",
   "description": "",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "scripts": {
     "build": "yarn run clean && yarn tsc",

--- a/src/creates/create-order.ts
+++ b/src/creates/create-order.ts
@@ -25,6 +25,7 @@ export const CreateOrder: ZapierCreate<CreateData> = {
   noun: "order",
   display: {
     label: "Create Order",
+    important: true,
     description: "Creates a new order.",
   },
   operation: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,15 @@ export default {
   beforeRequest: [addApiKeyHeader],
   authentication: {
     type: "custom",
-    fields: [{ key: "apiKey", type: "string" }],
+    fields: [
+      {
+        key: "apiKey",
+        type: "string",
+        helpText:
+          "Can be found on the [API Keys](https://dashboard.usepatch.com/api_keys) page of the Patch dashboard",
+      },
+    ],
+    connectionLabel: "Patch",
     test: async (z: ZObject): Promise<void> => {
       const response = await z.request("https://api.usepatch.com/v1/orders", {
         json: { page: 1 },

--- a/src/triggers/order.ts
+++ b/src/triggers/order.ts
@@ -15,6 +15,7 @@ export const OrderTrigger: ZapierTrigger = {
   noun: "order",
   display: {
     label: "New Order",
+    important: true,
     description: "Triggers when a new order is created.",
   },
   operation: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ type ZapierBase<BundleConfig> = {
   noun: string;
   display: {
     label: string;
+    important?: boolean;
     description: string;
   };
   operation: {


### PR DESCRIPTION
### Added
* Adds help text for the API keys
* Adds `createOrder` as an important action